### PR TITLE
Expanded API, Added ability to check player's inventory, enderchest

### DIFF
--- a/Hypixel.NET/SkyblockApi/Profile/EnderChestContents.cs
+++ b/Hypixel.NET/SkyblockApi/Profile/EnderChestContents.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hypixel.NET.SkyblockApi.Profile
+{
+    public class EnderChestContents
+    {
+        [JsonProperty("type")]
+        public long Type { get; private set; }
+
+        [JsonProperty("data")]
+        public string Data { get; private set; }
+    }
+}

--- a/Hypixel.NET/SkyblockApi/Profile/FishingBag.cs
+++ b/Hypixel.NET/SkyblockApi/Profile/FishingBag.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hypixel.NET.SkyblockApi.Profile
+{
+    public class FishingBag
+    {
+        [JsonProperty("type")]
+        public long Type { get; private set; }
+
+        [JsonProperty("data")]
+        public string Data { get; private set; }
+    }
+}

--- a/Hypixel.NET/SkyblockApi/Profile/InvContents.cs
+++ b/Hypixel.NET/SkyblockApi/Profile/InvContents.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hypixel.NET.SkyblockApi.Profile
+{
+    public class InvContents
+    {
+        [JsonProperty("type")]
+        public long Type { get; private set; }
+
+        [JsonProperty("data")]
+        public string Data { get; private set; }
+    }
+}

--- a/Hypixel.NET/SkyblockApi/Profile/MemberList.cs
+++ b/Hypixel.NET/SkyblockApi/Profile/MemberList.cs
@@ -86,5 +86,53 @@ namespace Hypixel.NET.SkyblockApi.Profile
 
         [JsonProperty("achievement_spawned_island_types")]
         public List<string> AchivementSpawnedIslandTypes { get; private set; }
+
+        [JsonProperty("experience_skill_runecrafting")]
+        public double ExperienceSkillRunecrafting { get; set; }
+
+        [JsonProperty("experience_skill_combat")]
+        public double ExperienceSkillCombat { get; set; }
+
+        [JsonProperty("experience_skill_mining")]
+        public double ExperienceSkillMining { get; set; }
+
+        [JsonProperty("unlocked_coll_tiers")]
+        public List<string> UnlockedCollTiers { get; set; }
+
+        [JsonProperty("fishing_bag")]
+        public FishingBag FishingBag { get; set; }
+
+        [JsonProperty("experience_skill_alchemy")]
+        public double ExperienceSkillAlchemy { get; set; }
+
+        [JsonProperty("experience_skill_farming")]
+        public double ExperienceSkillFarming { get; set; }
+
+        [JsonProperty("quiver")]
+        public Quiver Quiver { get; set; }
+
+        [JsonProperty("ender_chest_contents")]
+        public EnderChestContents EnderChestContents { get; set; }
+
+        [JsonProperty("potion_bag")]
+        public PotionBag PotionBag { get; set; }
+
+        [JsonProperty("experience_skill_enchanting")]
+        public double ExperienceSkillEnchanting { get; set; }
+
+        [JsonProperty("experience_skill_fishing")]
+        public double ExperienceSkillFishing { get; set; }
+
+        [JsonProperty("inv_contents")]
+        public InvContents InvContents { get; set; }
+
+        [JsonProperty("talisman_bag")]
+        public TalismanBag TalismanBag { get; set; }
+
+        [JsonProperty("experience_skill_foraging")]
+        public double ExperienceSkillForaging { get; set; }
+
+        [JsonProperty("experience_skill_carpentry")]
+        public double ExperienceSkillCarpentry { get; set; }
     }
 }

--- a/Hypixel.NET/SkyblockApi/Profile/PotionBag.cs
+++ b/Hypixel.NET/SkyblockApi/Profile/PotionBag.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hypixel.NET.SkyblockApi.Profile
+{
+    public class PotionBag
+    {
+        [JsonProperty("type")]
+        public long Type { get; private set; }
+
+        [JsonProperty("data")]
+        public string Data { get; private set; }
+    }
+}

--- a/Hypixel.NET/SkyblockApi/Profile/Quiver.cs
+++ b/Hypixel.NET/SkyblockApi/Profile/Quiver.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hypixel.NET.SkyblockApi.Profile
+{
+    public class Quiver
+    {
+        [JsonProperty("type")]
+        public long Type { get; private set; }
+
+        [JsonProperty("data")]
+        public string Data { get; private set; }
+    }
+}

--- a/Hypixel.NET/SkyblockApi/Profile/TalismanBag.cs
+++ b/Hypixel.NET/SkyblockApi/Profile/TalismanBag.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hypixel.NET.SkyblockApi.Profile
+{
+    public class TalismanBag
+    {
+        [JsonProperty("type")]
+        public long Type { get; private set; }
+
+        [JsonProperty("data")]
+        public string Data { get; private set; }
+    }
+}


### PR DESCRIPTION
and bags. 

Todo: Add ability to check collection tiers and Slayer bosses progress.

The API calls I added only appear if the player allows it. To change settings the player needs to go to "Skyblock Menu" (The nether star) in game then go to "Settings" then to "API settings" and enable all of them to allow the API to get the player's inventory and Collection tiers progress (Which still needs to be added to the API Wrapper)

